### PR TITLE
Filter out all messages before last clear.

### DIFF
--- a/backend/src/internal/collector/collector.go
+++ b/backend/src/internal/collector/collector.go
@@ -32,6 +32,36 @@ func NewCollector(writer io.WriteCloser, reader io.ReadSeeker) *Collector {
 	}
 }
 
+func isClearMessage(input []byte) bool {
+	return message.GetRootAsMessage(input, 0).Action() == message.ActionClear
+}
+
+func sinceLastClear(input [][]byte) [][]byte {
+	idx := len(input)
+
+	for {
+		if idx == 0 {
+			break
+		}
+
+		idx = idx - 1
+
+		if isClearMessage(input[idx]) {
+			break
+		}
+	}
+
+	return input[idx:]
+}
+
+func (s *Collector) ReadSinceLastClear() ([][]byte, error) {
+	if messages, err := s.Read(); err != nil {
+		return make([][]byte, 0), err
+	} else {
+		return sinceLastClear(messages), nil
+	}
+}
+
 func (s *Collector) Read() ([][]byte, error) {
 	var messages [][]byte
 

--- a/backend/src/internal/messaging/hub.go
+++ b/backend/src/internal/messaging/hub.go
@@ -37,7 +37,7 @@ func (h *Hub) run() {
 
 		case client := <-h.register:
 			h.clients[client] = true
-			messages, err := h.collector.Read()
+			messages, err := h.collector.ReadSinceLastClear()
 			if err != nil {
 				log.Printf("Failed to read from log: %v", err)
 			} else {


### PR DESCRIPTION
# Issue
The current implementation plays back _all_ drawing events from the beginning. Some of the events are "clear canvas" events, makeing all preceding events useless.

# This PR...
Filters drawing events before the last clear. So now only relevant events are sent, but the history is kept intact for use in future features.